### PR TITLE
Update emongo.erl for Geospatial queries and 2d indexed databases

### DIFF
--- a/src/emongo.erl
+++ b/src/emongo.erl
@@ -1015,7 +1015,10 @@ convert_key(size)      -> <<"$size">>;
 convert_key(exists)    -> <<"$exists">>;
 convert_key(near)      -> <<"$near">>;
 convert_key(where)     -> <<"$where">>;
-convert_key(elemMatch) -> <<"$elemMatch">>.
+convert_key(elemMatch) -> <<"$elemMatch">>;
+convert_key(maxDistance) -> <<"$maxDistance">>;
+convert_key(geoWithin) -> <<"$geoWithin">>;
+convert_key(center) -> <<"$center">>.
 
 force_data_type(<<"$in">>)  -> array;
 force_data_type(<<"$nin">>) -> array;


### PR DESCRIPTION
For geospacial indexed queries on 2d indexed collection.
usage:
> emongo:find_all(?MONGO_POOL_ID, Collection,
[{<<"loc">>,[{geoWithin,[{center,[[Long,Lat],?BBOX_RADIUS]}]}]],
[{fields, [{<<"_id">>,0}]} | Opts]