### PR TITLE
Fixed spelling for 'shutdown'

### DIFF
--- a/src/emongo.erl
+++ b/src/emongo.erl
@@ -749,7 +749,7 @@ handle_cast(_Msg, State) ->
 %                     {stop, Reason, State}
 % Description: Handling all non call/cast messages
 %--------------------------------------------------------------------
-handle_info({'EXIT', _, shudown}, State) ->
+handle_info({'EXIT', _, shutdown}, State) ->
   {noreply, State};
 
 handle_info({'EXIT', Pid, Error}, #state{pools = Pools} = State) ->

--- a/src/emongo_conn.erl
+++ b/src/emongo_conn.erl
@@ -129,7 +129,7 @@ loop(State = #state{socket = Socket,
     % timeout.
     % Throw a meaningful error that the emongo module can handle for connections that exit.
     case Error of
-      emongo_conn_close        -> exit(shudown);
+      emongo_conn_close        -> exit(shutdown);
       emongo_too_many_timeouts -> exit(normal);
       _                        ->
         ?EXCEPTION("Exiting: ~p", [Error]),


### PR DESCRIPTION
Fixed spelling for 'shutdown' that produced misleading shutdown error messages when deleting ad DB.

`2016-03-08 12:22:40.512 [error] line:Undefined module:Undefined CRASH REPORT Process <0.1455.0> with 0 neighbours exited with reason: shudown in emongo_conn:loop/1 line 132`

`2016-03-08 12:22:40 =CRASH REPORT====
  crasher:
    initial call: emongo_conn:init_loop/6
    pid: <0.1448.0>
    registered_name: []
    exception exit: {shudown,[{emongo_conn,loop,1,[{file,"/home/workspace/product_feed/_build/default/lib/emongo/src/emongo_conn.erl"},{line,132}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}
    ancestors: [emongo,<0.1408.0>]
    messages: []
    links: [<0.1409.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 610
    stack_size: 27
    reductions: 731
  neighbours:
`