### PR TITLE
Added support for SCRAM-SHA-1 authentication

### DIFF
--- a/include/emongo.hrl
+++ b/include/emongo.hrl
@@ -37,6 +37,7 @@
                port,
                database,
                size                  = 1,
+               auth_db               = undefined,
                user                  = undefined,
                pass_hash             = undefined,
                max_pipeline_depth    = 0,

--- a/include/emongo_public.hrl
+++ b/include/emongo_public.hrl
@@ -8,6 +8,9 @@
 -define(USE_PRIMARY, use_primary).
 -define(OPLOG, 8).
 -define(NO_CURSOR_TIMEOUT, 16).
+-define(AWAIT_DATA, 32).
+-define(EXHAUST, 64).
+-define(PARTIAL, 128).
 
 -define(EMONGO_PUBLIC, true).
 -endif.

--- a/src/emongo.erl
+++ b/src/emongo.erl
@@ -239,7 +239,7 @@ find_one(PoolId, Collection, Selector) when ?IS_DOCUMENT(Selector) ->
 
 find_one(PoolId, Collection, Selector, Options) when ?IS_DOCUMENT(Selector),
                                                      is_list(Options) ->
-  Options1 = [{limit, 1} | lists:keydelete(limit, 1, Options)],
+  Options1 = [{limit, -1} | lists:keydelete(limit, 1, Options)],
   find(PoolId, Collection, Selector, Options1).
 
 %------------------------------------------------------------------------------

--- a/test/emongo_test.erl
+++ b/test/emongo_test.erl
@@ -40,6 +40,7 @@ run_test_() ->
       fun test_upsert/0, % rerun upsert to make sure we can still do our work
       fun test_empty_sel_with_orderby/0,
       fun test_count/0,
+      fun test_find_one/0,
       fun test_encoding_performance/0,
       {timeout, ?TIMEOUT div 1000, [fun test_performance/0]}
     ]
@@ -119,6 +120,13 @@ test_count() ->
                                ?FIND_OPTIONS)),
   ?assertEqual(3, emongo:count(?POOL, ?COLL, [{<<"$and">>, [[{<<"a">>, [{gte, 2}]}], [{<<"a">>, [{lte, 4}]}]]}],
                                ?FIND_OPTIONS)),
+  clear_coll(),
+  ?OUT("Test passed", []).
+
+test_find_one() ->
+  ?OUT("Testing find_one", []),
+  emongo:insert_sync(?POOL, ?COLL, [[{<<"a">>, 1}], [{<<"a">>, 2}], [{<<"a">>, 2}], [{<<"a">>, 3}], [{<<"a">>, 3}]]),
+  ?assertEqual(1, length(emongo:find_one(?POOL, ?COLL, [{<<"a">>, 2}], ?FIND_OPTIONS))),
   clear_coll(),
   ?OUT("Test passed", []).
 


### PR DESCRIPTION
1. As of mongo 3.0, the default authentication mechanism is SCRAM-SHA-1, since it is more secure than the Challenge/Response authentication mechanism.  The driver will automatically select SCRAM-SHA-1 authentication if it is supported by the mongo server, so it is backwards-compatible for previous versions of mongo.
2. The register_collections_to_databases function now supports an optional flag that specifies whether or not to authenticate with the given database.  This flag was added so that an application can choose a subset of databases to authenticate against, which is useful since SCRAM-SHA-1 authentication has more overhead than CR authentication
3. Included changes to support erlang 18.1, since os:timestamp support was removed.
4. Specify limit as -1 to work around Mongo DB issue where find_one will leave a cursor open until mongodb kills it [https://jira.mongodb.org/browse/SERVER-19915]
